### PR TITLE
Integrate FFT bloom with Volume workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,14 @@
  また自前で色深度が十分なpng画像を用意できるならUse256x4のチェックはせずにConvolution Kernelを使うこともできます。  
 
 ### Intensity
- 畳み込み画像に適応される色倍率です。  
- ブラー用途では1.0、Convolution Bloom用途では100.0くらいが適切な値です。  
+畳み込み画像に適応される色倍率です。
+ブラー用途では1.0、Convolution Bloom用途では100.0くらいが適切な値です。
 
-## 2.SettingsのUniversalRendererにアタッチしてあるFeature  
+## 2.Post-process Volumeでの設定
+UniversalRendererを直接編集しなくても、Volume Profileに**Bloom FFT**を追加すれば
+IntensityやThresholdを他のエフェクトと同じように調整できます。
+
+## 3.SettingsのUniversalRendererにアタッチしてあるFeature
  <img width="460" alt="setumei2.png" src="https://user-images.githubusercontent.com/44022497/230786919-4ac6aabd-bdba-4df5-b4fc-e948c3e7cf42.png">
  
 ### Selected Pass

--- a/URP_FFT_Bloom/Assets/FFTConvolutionBloom/Scripts/VolumePost.meta
+++ b/URP_FFT_Bloom/Assets/FFTConvolutionBloom/Scripts/VolumePost.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 98a0af5be64e4450bdaf14af2f8c2dcf
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/URP_FFT_Bloom/Assets/FFTConvolutionBloom/Scripts/VolumePost/BloomFFTRenderer.cs
+++ b/URP_FFT_Bloom/Assets/FFTConvolutionBloom/Scripts/VolumePost/BloomFFTRenderer.cs
@@ -1,0 +1,79 @@
+using UnityEngine;
+using UnityEngine.Rendering;
+using UnityEngine.Rendering.Universal;
+
+public class BloomFFTRenderer : ScriptableRendererFeature
+{
+    class BloomFFTPass : ScriptableRenderPass
+    {
+        private Material _material;
+        private FFTBloom _fft;
+        private RenderTargetIdentifier _source;
+        private RenderTargetHandle _temp;
+        public BloomFFTVolume settings;
+
+        public BloomFFTPass(Shader shader)
+        {
+            _material = CoreUtils.CreateEngineMaterial(shader);
+            renderPassEvent = RenderPassEvent.AfterRenderingPostProcessing;
+            _temp.Init("_BloomFFTTemp");
+        }
+
+        public void Setup(RenderTargetIdentifier source)
+        {
+            _source = source;
+        }
+
+        public void SetFFT(FFTBloom fft) => _fft = fft;
+
+        public override void Execute(ScriptableRenderContext context, ref RenderingData renderingData)
+        {
+            if (settings == null || !settings.IsActive() || _fft == null)
+                return;
+
+            var cmd = CommandBufferPool.Get("Bloom FFT");
+
+            _material.SetFloat("_Intensity", settings.intensity.value);
+            _material.SetFloat("_Threshold", settings.threshold.value);
+
+            var desc = renderingData.cameraData.cameraTargetDescriptor;
+            desc.depthBufferBits = 0;
+            cmd.GetTemporaryRT(_temp.id, desc);
+
+            cmd.Blit(_source, _temp.Identifier());
+            _fft.FFTConvolutionFromRenderPass(cmd, _temp.id, _temp.id);
+            cmd.Blit(_temp.Identifier(), _source, _material);
+
+            context.ExecuteCommandBuffer(cmd);
+            CommandBufferPool.Release(cmd);
+        }
+    }
+
+    [SerializeField] Shader shader;
+    BloomFFTPass _pass;
+
+    public override void Create()
+    {
+        _pass = new BloomFFTPass(shader);
+    }
+
+    public override void AddRenderPasses(ScriptableRenderer renderer, ref RenderingData renderingData)
+    {
+        var stack = VolumeManager.instance.stack.GetComponent<BloomFFTVolume>();
+        if (stack == null || !stack.IsActive())
+            return;
+
+        if (_pass == null)
+            Create();
+
+        _pass.settings = stack;
+        _pass.Setup(renderer.cameraColorTarget);
+
+        var fft = renderingData.cameraData.camera.GetComponent<FFTBloom>();
+        if (fft != null)
+        {
+            _pass.SetFFT(fft);
+            renderer.EnqueuePass(_pass);
+        }
+    }
+}

--- a/URP_FFT_Bloom/Assets/FFTConvolutionBloom/Scripts/VolumePost/BloomFFTRenderer.cs.meta
+++ b/URP_FFT_Bloom/Assets/FFTConvolutionBloom/Scripts/VolumePost/BloomFFTRenderer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ea97c14433854e8b89588e314655e56f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/URP_FFT_Bloom/Assets/FFTConvolutionBloom/Scripts/VolumePost/BloomFFTVolume.cs
+++ b/URP_FFT_Bloom/Assets/FFTConvolutionBloom/Scripts/VolumePost/BloomFFTVolume.cs
@@ -1,0 +1,13 @@
+using System;
+using UnityEngine;
+using UnityEngine.Rendering;
+
+[Serializable, VolumeComponentMenu("Post-processing/Custom/Bloom FFT")]
+public class BloomFFTVolume : VolumeComponent, IPostProcessComponent
+{
+    public ClampedFloatParameter intensity = new ClampedFloatParameter(1f, 0f, 10f);
+    public FloatParameter threshold = new FloatParameter(1f);
+
+    public bool IsActive() => intensity.value > 0f;
+    public bool IsTileCompatible() => false;
+}

--- a/URP_FFT_Bloom/Assets/FFTConvolutionBloom/Scripts/VolumePost/BloomFFTVolume.cs.meta
+++ b/URP_FFT_Bloom/Assets/FFTConvolutionBloom/Scripts/VolumePost/BloomFFTVolume.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c0d051530a7442339f55699e5f5d3daa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add `BloomFFTVolume` and `BloomFFTRenderer` for Volume based control
- document the new Volume workflow in the README

## Testing
- `echo 'no tests'`

------
https://chatgpt.com/codex/tasks/task_e_688112c87d80832d86394a5600f32873